### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:15.04
 MAINTAINER JP <jportela@abyssal.eu>
 ENV LANG en_US.utf8
-RUN apt-get update && apt-get install -yq \
+RUN apt-get update && apt-get install --no-install-recommends -yq \
     python3-all \
     python3-pip \
     python3-nose \


### PR DESCRIPTION
Added --no-install-recommends flag to apt-get install command. This reduces the Image size from 401.6 MB to 204.7 MB. That is around 50% reduction in size. I have docker-built and tested the above Docker file and it works perfectly. Please accept my proposal for the file change.
